### PR TITLE
Remove entry__title class from link CSS selector

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -43,7 +43,7 @@ async function open() {
     }
 
     await Promise.all([...unread].map(x => browser.runtime.sendMessage({
-        href: x.querySelector('a.entry__title').href
+        href: x.querySelector('div.content > a').href
     })))
 
     if (await shouldMarkRead()) {


### PR DESCRIPTION
This class doesn't appear anymore. Instead, the correct link can be found under the div with the content class